### PR TITLE
Feature/grouped transactions

### DIFF
--- a/src/main/java/com/finsight/TransactionService/Controller/TransactionController.java
+++ b/src/main/java/com/finsight/TransactionService/Controller/TransactionController.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Sort;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -80,6 +81,7 @@ public class TransactionController {
             existingTransaction.setDescription(updatedTransaction.getDescription());
             existingTransaction.setAmount(updatedTransaction.getAmount());
             existingTransaction.setDate(updatedTransaction.getDate());
+            existingTransaction.setGroup_id(updatedTransaction.getGroup_id());
 
             // Sla de bijgewerkte transactie op
             transactionService.saveTransaction(existingTransaction);
@@ -136,6 +138,7 @@ public class TransactionController {
                             .date(parsedDate)
                             .rowHash(hash)
                             .classificationSource(0)
+                            .group_id(csvRecord.getId())
                             .build();
 
                     transactionService.saveTransaction(transaction);
@@ -171,6 +174,7 @@ public class TransactionController {
                 existing.setClassificationSource(updated.getClassificationSource());
                 existing.setCategory(updated.getCategory());
                 existing.setDate(updated.getDate());
+                existing.setGroup_id(updated.getGroup_id());
 
                 transactionService.saveTransaction(existing);
             }

--- a/src/main/java/com/finsight/TransactionService/Entity/Transaction.java
+++ b/src/main/java/com/finsight/TransactionService/Entity/Transaction.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 
 @Entity
@@ -40,13 +41,17 @@ public class Transaction {
     @Column(name = "classification_source", nullable = false)
     private Integer classificationSource = 0;
 
-    public Transaction(String account, String category, String recipient, String description, BigDecimal amount, LocalDate date) {
+    @Column(name = "group_id", nullable = false)
+    private BigInteger group_id;
+
+    public Transaction(String account, String category, String recipient, String description, BigDecimal amount, LocalDate date, BigInteger group_id) {
         this.account = account;
         this.category = category;
         this.recipient = recipient;
         this.description = description;
         this.amount = amount;
         this.date = date;
+        this.group_id = group_id;
     }
 }
 

--- a/src/main/java/com/finsight/TransactionService/Entity/Transaction.java
+++ b/src/main/java/com/finsight/TransactionService/Entity/Transaction.java
@@ -41,10 +41,10 @@ public class Transaction {
     @Column(name = "classification_source", nullable = false)
     private Integer classificationSource = 0;
 
-    @Column(name = "group_id", nullable = false)
-    private BigInteger group_id;
+    @Column(name = "group_id")
+    private Long group_id;
 
-    public Transaction(String account, String category, String recipient, String description, BigDecimal amount, LocalDate date, BigInteger group_id) {
+    public Transaction(String account, String category, String recipient, String description, BigDecimal amount, LocalDate date, Long group_id) {
         this.account = account;
         this.category = category;
         this.recipient = recipient;

--- a/src/main/java/com/finsight/TransactionService/Service/TransactionService.java
+++ b/src/main/java/com/finsight/TransactionService/Service/TransactionService.java
@@ -48,7 +48,15 @@ public class TransactionService {
      * @return The saved transaction.
      */
     public Transaction saveTransaction(Transaction transaction) {
-        return transactionRepository.save(transaction);
+        Transaction saved = transactionRepository.save(transaction);
+
+        // Set the id first, then if group_id = null copy the value into group_id
+        if (saved.getGroup_id() == null) {
+            saved.setGroup_id(saved.getTransactionsId());
+            saved = transactionRepository.save(saved);
+        }
+
+        return saved;
     }
 
     public boolean existsByRowHash(String rowHash) {


### PR DESCRIPTION
This PR introduces a group_id column on transactions.
The purpose of this field is to logically group transactions, for example when amounts are advanced and later reimbursed.
In this case the user can append them to the same transaction group.
Each transaction starts in its own group by default (group_id = transaction_id).
